### PR TITLE
use conda to get binary packages of numpy/scipy for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,32 @@
-before_install:
-  # install numpy and scipy before, otherwise travis will compile them
-  # everytime it runs the tests
-  - sudo apt-get install -qq python-numpy python-scipy
-virtualenv:
-  system_site_packages: true
 language: python
 python:
-  - "2.7"
+  - "3.4"
 install:
-  # filter numpy and scipy
-  - "grep -vE 'numpy|scipy' requirements.txt > .travis-requirements.txt"
-  - "pip install -r .travis-requirements.txt"
+  # pip compiles a lot of scipy and numpy C Code at installation. to enable fast
+  # travis test we use an exotic package manager called miniconda, which provides
+  # binary packages of numpy and scipy.
+  #
+  # This `.travis.yml` files is adapted from: http://conda.pydata.org/docs/travis.html
+  # You may want to periodically update this, although the conda update
+  # conda line below will keep everything up-to-date.
+  - wget http://repo.continuum.io/miniconda/Miniconda3-3.4.2-Linux-x86_64.sh -O miniconda.sh;
+  - bash miniconda.sh -b -p $HOME/miniconda
+  - export PATH="$HOME/miniconda/bin:$PATH"
+  - hash -r
+  - conda config --set always_yes yes --set changeps1 no
+  - conda update conda
+  # Useful for debugging any issues with conda
+  - conda info -a
+  - echo "`sed 's/==/=/' < requirements.txt`"
+  - CONDA_DEPS=$(grep -E 'numpy|scipy' requirements.txt | sed 's/==/=/')
+  - PIP_DEPS=$(grep -vE 'numpy|scipy' requirements.txt )
+  # Usefull for debugging
+  - echo $CONDA_DEPS
+  - echo $PIP_DEPS
+  - conda create -n test-environment python=$TRAVIS_PYTHON_VERSION $CONDA_DEPS pip
+  - source activate test-environment
+  - pip install $PIP_DEPS
+  - python setup.py install
 script:
   - ./travis.sh
 notifications:


### PR DESCRIPTION
Hi,

travis ci now uses python 3.4 and binary packages of numpy and scipy. This enables faster test runs than downloading numpy/scipy with pip and compiling a lot of C code.
